### PR TITLE
Fix a Nasal Runtime error with the E-3 AEW&C

### DIFF
--- a/Nasal/E-3/rwr.nas
+++ b/Nasal/E-3/rwr.nas
@@ -416,7 +416,7 @@ RWRCanvas = {
                 me.symbol_priority.show();
                 me.prio = 1;
             }
-            if (me.contact[0].getType() == armament.AIR) {
+            if (me.contact[0].getType() == radar_system.AIR) {
                 #air-borne
                 me.symbol_hat[me.i].setTranslation(me.x,me.y);
                 me.symbol_hat[me.i].show();


### PR DESCRIPTION
Today, when flying the E-3 AEW&C, I encountered a Nasal runtime error:

```bash
4697.10 [ALRT]:nasal      Nasal runtime error: undefined symbol: armament
4697.10 [ALRT]:nasal        at /home/lolo/Documents/Resources/Cromha/FlightGear shit/Custom Aircraft/KC-137R/Nasal/E-3/rwr.nas, line 419
4697.10 [ALRT]:nasal        called from: /home/lolo/Documents/Resources/Cromha/FlightGear shit/Custom Aircraft/KC-137R/Nasal/E-3/rwr.nas, line 521

```

This PR fixes that error. I also believe that this runtime error may have been preventing the radar from working, as I couldn't get a contact on the radar, even though it was 50NM away at Fl250...